### PR TITLE
Change symbolic icon reference

### DIFF
--- a/package/contents/ui/PopupDialog.qml
+++ b/package/contents/ui/PopupDialog.qml
@@ -103,7 +103,7 @@ FocusScope {
         }
         PlasmaComponents.ToolButton {
             Layout.fillWidth: true
-            iconSource: "emblem-shared-symbolic"
+            iconSource: "document-share"
             tooltip: i18n("Configure shared resources...")
 
             text: i18n("Shared resources")


### PR DESCRIPTION
Symbolic icons are for GTK compatibility Plasma does not use them.